### PR TITLE
fix: quotes section miss backdrop blur of header & some more code formatting 

### DIFF
--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -5,25 +5,25 @@ const formLink =
   "https://c42d.typeform.com/to/zJV3Cx?typeform-source=www.c42d.com";
 ---
 
-<nav class="py-2 border-b fixed top-0 right-0 left-0 backdrop-blur">
+<nav class="py-2 border-b fixed top-0 right-0 left-0 backdrop-blur z-10">
 	<div class="flex items-center justify-between container mx-auto">
 		<a href="/">
-		<img src="/logo.png" alt="Logo" height="64px" width="64px" />
+			<img src="/logo.png" alt="Logo" height="64px" width="64px" />
 		</a>
 		<span class="font-bold text-sm md:text-lg">C42D</span>
 		<div class="flex items-center gap-4">
-		<div class="flex items-center gap-2">
-			<a target="_blank" href={formLink}>
-			<span
-				class="font-bold text-sm md:text-lg hover:text-brandYellow transition delay-150 cursor-pointer tracking-wide"
-				>Start a Project</span
-			>
-			</a>
-			<Icon name="arrowUpRight" class="text-brandYellow" />
-		</div>
-		<button>
-			<Icon name="equal" class="text-brandYellow" />
-		</button>
+			<div class="flex items-center gap-2">
+				<a target="_blank" href={formLink}>
+				<span
+					class="font-bold text-sm md:text-lg hover:text-brandYellow transition delay-150 cursor-pointer tracking-wide"
+					>Start a Project</span
+				>
+				</a>
+				<Icon name="arrowUpRight" class="text-brandYellow" />
+			</div>
+			<button>
+				<Icon name="equal" class="text-brandYellow" />
+			</button>
 		</div>
 	</div>
 </nav>

--- a/src/components/index/Quotes.astro
+++ b/src/components/index/Quotes.astro
@@ -2,43 +2,42 @@
 import SingleQuote from "./SingleQuote.astro";
 ---
 
-<section class="relative p-16">
+<section class="h-96 relative m-16">
 	<div class="quote">
 		<SingleQuote
-			name="Mallory Walsh"
+			name="mallory walsh"
 			post="head of marketing, teal health"
-			quote="I could not be happier with my decision to select C42D for this project; they were the most responsive, detailed, and efficient agency I’ve ever experienced. I could not be more proud of the work we created together and the brand we’ve built."
+			quote="i could not be happier with my decision to select c42d for this project; they were the most responsive, detailed, and efficient agency i’ve ever experienced. i could not be more proud of the work we created together and the brand we’ve built."
+		/>
+	</div>	
+	<div class="quote">
+		<SingleQuote
+			name="alexis rodriguez"
+			post="head of global marketing solutions, shazam"
+			quote="we’ve interviewed several other large firms, but the c42d team seemed to understand our goals more quickly than others."
 		/>
 	</div>
 	<div class="quote">
 		<SingleQuote
-			name="Alexis Rodriguez"
-			post="Head of Global Marketing Solutions, Shazam"
-			quote="We’ve interviewed several other large firms, but the C42D team seemed to understand our goals more quickly than others."
+			name="jay hack"
+			post="founder & ceo, mira ai"
+			quote="they truly seemed to understand our base and vision. work with c42d, they’re awesome. we highly recommend them."
 		/>
 	</div>
-	<div class="quote">
-		<SingleQuote
-			name="Jay Hack"
-			post="Founder & CEO, Mira AI"
-			quote="They truly seemed to understand our base and vision. Work with C42D, they’re awesome. We highly recommend them."
-		/>
-	</div>
-
-	<span
+	<div
 		id="left"
 		class="absolute text-4xl bottom-16 left-16 cursor-pointer text-brandYellow"
-		>&larr;</span
-	>
-	<span
+		>&larr;
+	</div>
+	<div
 		id="right"
 		class="absolute text-4xl bottom-16 right-16 cursor-pointer text-brandYellow"
-		onclick="plusSlider(1)">&rarr;</span
-	>
+		>&rarr;
+	</div>
 </section>
 
 <script>
-	let quoteIndex = 1;
+	let quoteIndex = 0;
 	showQuotes(quoteIndex);
 
 	document.getElementById("left").addEventListener("click", () => {
@@ -48,28 +47,22 @@ import SingleQuote from "./SingleQuote.astro";
 		showQuotes((quoteIndex += 1));
 	});
 
-	function showQuotes(n: number) {
-		let i: number;
-		let quotes = document.getElementsByClassName("quote");
+	function showQuotes(givenQuoteIndex) {
+		const allQuotes = document.getElementsByClassName("quote");
+		const lastQuoteIndex = allQuotes.length - 1
 
-		if (n > quotes.length) {
-			quoteIndex = 1;
+		if (givenQuoteIndex > lastQuoteIndex) {
+			quoteIndex = 0;
 		}
 
-		if (n < 1) {
-			quoteIndex = quotes.length;
+		if (givenQuoteIndex < 0) {
+			quoteIndex = lastQuoteIndex;
 		}
 
-		for (i = 0; i < quotes.length; i++) {
-			quotes[i].style.display = "none";
+		for (let i = 0; i < allQuotes.length; i++) {
+			allQuotes[i].classList.add("hidden")
 		}
 
-		quotes[quoteIndex - 1].style.display = "block";
+		allQuotes[quoteIndex].classList.remove("hidden")
 	}
-	</script>
-
-<style>
-	.quote {
-		display: none;
-	}
-</style>
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,46 +13,46 @@ import Blog from "../components/index/Blog.astro";
 		<Hero />
 		<Customers />
 		<div class="border-b">
-		<p class="uppercase text-2xl container py-2 font-serif">
-			area of speciality:
-		</p>
-		<Work
-			domain="healthcase"
-			work="Branding"
-			project="Kindbody"
-			img="/images/kindbody.png"
-			alt="Kindbody branding banner"
-		/>
-		<Work
-			work="Branding for venture capital"
-			project="Foundation Capital"
-			img="/images/foundation.png"
-			alt="Foundation branding banner"
-		/>
-		<Work
-			domain="ui/ux"
-			work="design"
-			project="The Humane Space"
-			img="/images/ux.png"
-			alt="The Humane branding banner"
-		/>
+			<p class="uppercase text-2xl py-2 font-serif">
+				area of speciality:
+			</p>
+			<Work
+				domain="healthcase"
+				work="Branding"
+				project="Kindbody"
+				img="/images/kindbody.png"
+				alt="Kindbody branding banner"
+			/>
+			<Work
+				work="Branding for venture capital"
+				project="Foundation Capital"
+				img="/images/foundation.png"
+				alt="Foundation branding banner"
+			/>
+			<Work
+				domain="ui/ux"
+				work="design"
+				project="The Humane Space"
+				img="/images/ux.png"
+				alt="The Humane branding banner"
+			/>
 		</div>
 		<div class="flex mt-32 lg:mt-64">
-		<Data
-			data="50"
-			title="verified reviews"
-			description="from real clients on clutch.co"
-		/>
-		<Data
-			data="4.9"
-			title="out of 5"
-			description="average referal rating on clutch.co"
-		/>
-		<Data
-			data="15"
-			title="years in business"
-			description="working from visionary companies"
-		/>
+			<Data
+				data="50"
+				title="verified reviews"
+				description="from real clients on clutch.co"
+			/>
+			<Data
+				data="4.9"
+				title="out of 5"
+				description="average referal rating on clutch.co"
+			/>
+			<Data
+				data="15"
+				title="years in business"
+				description="working from visionary companies"
+			/>
 		</div>
 		<Quotes
 			name="Kunal Singh"
@@ -60,21 +60,21 @@ import Blog from "../components/index/Blog.astro";
 			quote="I love you the more in that I believe you had liked me for my own sake and for nothing else I love you the more in that I believe you had liked me for my own sake and for nothing else"
 		/>
 		<div class="mb-32">
-		<Blog
-			title="C42D Client Midday Featured in Fast Company"
-			img="/images/blog/midday.png"
-			alt="Blog Midday Banner"
-		/>
-		<Blog
-			title="Clutch Names C42D a 2022 Top New York Branding Agenc BY DAVID CARD"
-			img="/images/blog/clutch.png"
-			alt="Blog Clutch Banner"
-		/>
-		<Blog
-			title="C42D Client Kindbody Chosen as a 2022 Breakthrough Brand by Interbrand"
-			img="/images/blog/kindbody.png"
-			alt="Blog Kindbody Banner"
-		/>
+			<Blog
+				title="C42D Client Midday Featured in Fast Company"
+				img="/images/blog/midday.png"
+				alt="Blog Midday Banner"
+			/>
+			<Blog
+				title="Clutch Names C42D a 2022 Top New York Branding Agenc BY DAVID CARD"
+				img="/images/blog/clutch.png"
+				alt="Blog Clutch Banner"
+			/>
+			<Blog
+				title="C42D Client Kindbody Chosen as a 2022 Breakthrough Brand by Interbrand"
+				img="/images/blog/kindbody.png"
+				alt="Blog Kindbody Banner"
+			/>
 		</div>
 	</div>
 </IndexLayout>


### PR DESCRIPTION
Since quote section was `relative` to fit 2 arrows which are `absolute`, this makes the element above the header, and backdrop filter dont work when element is above it, as name suggest things would be in background to make background blur. 

to fix this, i just make header `z-10` z-index 10 so it will be above every element. 